### PR TITLE
fix qQCReport par; set RNGkind in md5subsum

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: QuasR
 Type: Package
 Title: Quantify and Annotate Short Reads in R
-Version: 1.23.15
-Date: 2019-02-19
+Version: 1.23.16
+Date: 2019-03-12
 Author: Anita Lerch, Charlotte Soneson, Dimos Gaiditzis and Michael Stadler
 Maintainer: Michael Stadler <michael.stadler@fmi.ch>
 Depends: R (>= 3.6), parallel, GenomicRanges (>= 1.13.3), Rbowtie

--- a/R/qQCReport.R
+++ b/R/qQCReport.R
@@ -134,6 +134,8 @@ calcMmInformation <- function(filename, genome, chunkSize){
 
 qQCReport <- function(input, pdfFilename=NULL, chunkSize=1e6L, useSampleNames=FALSE, clObj=NULL, ...)
 {
+    gpars <- par()
+    on.exit(par(gpars))
     # 'proj' is correct type?
     if(inherits(input, "qProject", which=FALSE)){
         filetype <- input@samplesFormat

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -218,7 +218,7 @@ md5subsum <-
         # (non-uniform, see https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17494,
         #  but QuasR on R-3.6 would otherwise re-create all bam files created by QuasR on R-3.5 or earlier)
         suppressWarnings(rng.orig <- RNGkind(kind = "Mersenne-Twister", normal.kind = "Inversion", sample.kind = "Rounding"))
-        on.exit(RNGkind(kind = rng.orig[1], normal.kind = rng.orig[2], sample.kind = rng.orig[3]))
+        on.exit(suppressWarnings(RNGkind(kind = rng.orig[1], normal.kind = rng.orig[2], sample.kind = rng.orig[3])))
         
         # calculate md5sum() on a repoducible random subset of the file's content
         unlist(lapply(filenames, function(fname) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -214,6 +214,12 @@ compressFile <-
 
 md5subsum <-
     function(filenames) {
+        # use RNG kind for sample() from R version 3.5 and earlier
+        # (non-uniform, see https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17494,
+        #  but QuasR on R-3.6 would otherwise re-create all bam files created by QuasR on R-3.5 or earlier)
+        suppressWarnings(rng.orig <- RNGkind(kind = "Mersenne-Twister", normal.kind = "Inversion", sample.kind = "Rounding"))
+        on.exit(RNGkind(kind = rng.orig[1], normal.kind = rng.orig[2], sample.kind = rng.orig[3]))
+        
         # calculate md5sum() on a repoducible random subset of the file's content
         unlist(lapply(filenames, function(fname) {
             funit <- 1e6

--- a/tests/testthat/setup_test-environment.R
+++ b/tests/testthat/setup_test-environment.R
@@ -1,5 +1,3 @@
-RNGversion("3.5")
-
 # copy sample data
 file.copy(system.file("extdata", package = "QuasR"), ".", recursive = TRUE)
 

--- a/tests/testthat/setup_test-environment.R
+++ b/tests/testthat/setup_test-environment.R
@@ -1,3 +1,5 @@
+RNGversion("3.5")
+
 # copy sample data
 file.copy(system.file("extdata", package = "QuasR"), ".", recursive = TRUE)
 


### PR DESCRIPTION
I ended up using `RNGkind()` instead of `RNGversion()` (the latter is a wrapper around the former, and the former also allows to capture the initial settings to be re-set at the end of `md5subsum`)