### PR TITLE
Resync with Rhtslib 1.99.1 (updated from htslib 1.7 to 1.15.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: QuasR
 Type: Package
 Title: Quantify and Annotate Short Reads in R
-Version: 1.37.0
-Date: 2022-04-01
+Version: 1.37.1
+Date: 2022-05-03
 Authors@R: c(person("Anita", "Lerch", role = c("aut")),
              person("Charlotte", "Soneson", role = c("aut"), 
                     email = "charlottesoneson@gmail.com", 
@@ -28,7 +28,7 @@ Imports:
     Biobase,
     Biostrings,
     BSgenome,
-    Rsamtools,
+    Rsamtools (>= 2.13.1),
     GenomicFeatures,
     ShortRead,
     BiocParallel,
@@ -45,7 +45,7 @@ Suggests:
     rmarkdown,
     covr,
     testthat
-LinkingTo: Rhtslib
+LinkingTo: Rhtslib (>= 1.99.1)
 Encoding: UTF-8
 SystemRequirements: GNU make
 Description: This package provides a framework for the quantification

--- a/src/bam.c
+++ b/src/bam.c
@@ -1,1 +1,0 @@
-#include <bam.c>

--- a/src/cat_bam.c
+++ b/src/cat_bam.c
@@ -1,5 +1,4 @@
 #include "cat_bam.h"
-#include "bam.h"
 
 int bam_cat(int, char * const *, const bam_hdr_t *, const char *);
 

--- a/src/count_junctions.h
+++ b/src/count_junctions.h
@@ -6,6 +6,6 @@
 // include Boolean.h early, will define TRUE/FALSE enum prefent Rdefines.h from defining them as int constants
 #include <R_ext/Boolean.h>
 #include <Rdefines.h>
-#include "sam.h"
+#include <samtools-1.7-compat.h>
 
 SEXP count_junctions(SEXP bamfile, SEXP tid, SEXP start, SEXP end, SEXP allelic, SEXP includeSecondary, SEXP mapqMin, SEXP mapqMax);

--- a/src/extract_unmapped_reads.h
+++ b/src/extract_unmapped_reads.h
@@ -1,7 +1,7 @@
 // include Boolean.h early, will define TRUE/FALSE enum prefent Rdefines.h from defining them as int constants
 #include <R_ext/Boolean.h>
 #include <Rdefines.h>
-#include "sam.h"
+#include <samtools-1.7-compat.h>
 #include <stdio.h>
 
 SEXP extract_unmapped_reads(SEXP inBam, SEXP outFile, SEXP fastq, SEXP rcRead2);

--- a/src/filter_hisat2.h
+++ b/src/filter_hisat2.h
@@ -1,5 +1,4 @@
 #include <Rdefines.h>
 #include "utilities.h"
-#include "sam.h"
 
 SEXP filter_hisat2(SEXP samFile, SEXP outFile, SEXP maxHits);

--- a/src/idxstats_bam.h
+++ b/src/idxstats_bam.h
@@ -3,10 +3,9 @@
 // include Boolean.h early, will define TRUE/FALSE enum prefent Rdefines.h from defining them as int constants
 #include <R_ext/Boolean.h>
 #include <Rdefines.h>
-#include "sam.h"
+#include <samtools-1.7-compat.h>
 #include "htslib/khash.h"
 #include "htslib/ksort.h"
-#include "bam_endian.h"
 #ifdef _USE_KNETFILE
 #include "htslib/knetfile.h"
 #endif

--- a/src/nucleotide_alignment_frequencies.c
+++ b/src/nucleotide_alignment_frequencies.c
@@ -76,7 +76,7 @@ static int _nucleotide_alignment_frequencies(const bam1_t *b, void *data)
         }        
 
 	// get length of the query sequence
-	qlen = bam_cigar2qlen(&b->core, cigar);
+	qlen = bam_cigar2qlen(b->core.n_cigar, cigar);
 	if(fparam->len < qlen)
 	    fparam->len = qlen;
 	qlen = qlen - 1; // vector index starts with 0

--- a/src/remove_unmapped_from_sam.h
+++ b/src/remove_unmapped_from_sam.h
@@ -1,7 +1,7 @@
 // include Boolean.h early, will define TRUE/FALSE enum prefent Rdefines.h from defining them as int constants
 #include <R_ext/Boolean.h>
 #include <Rdefines.h>
-#include "sam.h"
+#include <samtools-1.7-compat.h>
 #include <stdio.h>
 
 SEXP remove_unmapped_from_sam_and_convert_to_bam(SEXP inSam, SEXP outBam);

--- a/src/sam.c
+++ b/src/sam.c
@@ -1,1 +1,0 @@
-#include <sam.c>

--- a/src/sam_opts.c
+++ b/src/sam_opts.c
@@ -1,0 +1,1 @@
+#include <sam_opts.c>

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <Rinternals.h>
-#include "sam.h"
+#include <samtools-1.7-compat.h>
 
 #define MIN_INTRON_LENGTH 60 // minimum length of an insertion for the alignment to be "spliced"
 


### PR DESCRIPTION
Dear **QuasR** maintainers,

After many years of using htslib 1.7 we're updating **Rhtslib** to use the latest version of htslib (i.e. version 1.15.1). This new version of **Rhtslib** (1.99.1) is ready to go and we'll push it to git.bioconductor.org later today so it becomes available in Bioconductor 3.16 in a couple of days. Unfortunately this update introduces changes that will break **QuasR**. This PR addresses this. Please merge at your earliest convenience.

Let me know if you have any questions about this.

Thanks,
H.